### PR TITLE
to install libgdal-java for gdaL extension

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - geoserver_geodata:/mnt/geoserver_geodata
       - geoserver_tiles:/mnt/geoserver_tiles
       - geoserver_native_libs:/mnt/geoserver_native_libs
+      - ./docker-entrypoint.sh:/docker-entrypoint.sh
     environment:
       - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
       - XMS=256M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
 
   geoserver:
     image: georchestra/geoserver:latest
+    user: root
     depends_on:
       - ldap
     volumes:


### PR DESCRIPTION
To install libgdal-java and create a symbolic link, the entrypoint script was updated and mounted.
   - ./docker-entrypoint.sh:/docker-entrypoint.sh
apt-get update && apt-get install libgdal-java && ln -s /usr/lib/jni/libgdalalljni.so.20 /usr/lib/libgdalalljni.so